### PR TITLE
Support for standalone Team Explorer 2017 installations

### DIFF
--- a/Import/ConformProject.ps1
+++ b/Import/ConformProject.ps1
@@ -25,6 +25,7 @@ $scriptFolder = Split-Path -Path $MyInvocation.MyCommand.Path
 
 $VSDirectories = @()
 $VSDirectories += "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer"
+$VSDirectories += "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\TeamExplorer\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer"
 $VSDirectories += "${env:ProgramFiles(x86)}\Microsoft Visual Studio 14.0\Common7\IDE"
 $VSDirectories += "${env:ProgramFiles(x86)}\Microsoft Visual Studio 12.0\Common7\IDE"
 $VSDirectories += "${env:ProgramFiles(x86)}\Microsoft Visual Studio 11.0\Common7\IDE"


### PR DESCRIPTION
FIXED: witadmin.exe from standalone Team Explorer 2017 is not detected.