### PR TITLE
Update ConformFromCSV.ps1

### DIFF
--- a/Import/ConformFromCSV.ps1
+++ b/Import/ConformFromCSV.ps1
@@ -32,7 +32,7 @@ FOREACH ($project in $projectList)
     Write-Host "    $projectName ($x) " -ForegroundColor White;
     Write-Host "-----------------------------------------------------------------------------------------------" -ForegroundColor White;
    
-    Invoke-Expression "& `".\ConformProject.ps1`" `"$CollectionURL`" `"$projectName`" `"$processfolder\$projectName`""
+    Invoke-Expression "& `".\ConformProject.ps1`" `"$CollectionURL`" `"$projectName`" `"$processfolder`""
     
     Write-Host ""
     Write-Host ""


### PR DESCRIPTION
Removed '\$projectName' from line 35. Including this causes the ConformProject.ps1 script to look for a subfolder within the process folder with the project's name. This appears to be an error.